### PR TITLE
fix(deploy): vercel web routing + render/api start config

### DIFF
--- a/apps/api/nixpacks.toml
+++ b/apps/api/nixpacks.toml
@@ -20,4 +20,4 @@ cmds = ['pnpm --filter=db db:generate', 'pnpm --filter=api build']
 # safe to run on every deploy. Kept in `start` (not `build`) so it runs when the
 # database is reachable, not during the build.
 [start]
-cmd = 'pnpm --filter=db db:migrate:deploy && node apps/api/dist/main'
+cmd = 'pnpm --filter=db db:migrate:deploy && node --import tsx apps/api/dist/main'

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,4 @@
 {
-  "framework": "nextjs",
   "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm build --filter=web",
-  "outputDirectory": "apps/web/.next"
+  "buildCommand": "pnpm --filter=db db:generate && next build"
 }

--- a/render.yaml
+++ b/render.yaml
@@ -21,8 +21,12 @@ services:
     plan: free
     region: virginia # us-east, matches the Neon us-east-1 DB for low latency
     rootDir: .
-    buildCommand: npm install -g pnpm@9.0.0 && pnpm install --frozen-lockfile && pnpm --filter=db db:generate && pnpm --filter=api build
-    startCommand: pnpm --filter=db db:migrate:deploy && node apps/api/dist/main
+    # Render provides pnpm natively (detects pnpm-lock.yaml) — installing it
+    # globally fails on Render's read-only /usr/lib, so call pnpm directly.
+    buildCommand: pnpm install --frozen-lockfile && pnpm --filter=db db:generate && pnpm --filter=api build
+    # @repo/db ships as TS source, so run the compiled API under tsx to resolve
+    # its extensionless TS imports (same as local dev / e2e).
+    startCommand: pnpm --filter=db db:migrate:deploy && node --import tsx apps/api/dist/main
     envVars:
       - key: NODE_VERSION
         value: "20"


### PR DESCRIPTION
Brings the deploy fixes to main (production source for Vercel + Render).

- vercel.json: remove outputDirectory so Next.js SSR is served (fixes 404), generate Prisma before build
- render.yaml: pnpm native + tsx start
- nixpacks.toml: tsx start

🤖 Generated with [Claude Code](https://claude.com/claude-code)