### PR TITLE
fix(vercel): declare framework:nextjs so SSR routing is applied

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,4 +1,5 @@
 {
+  "framework": "nextjs",
   "installCommand": "pnpm install --frozen-lockfile",
   "buildCommand": "pnpm --filter=db db:generate && next build"
 }


### PR DESCRIPTION
Production 404 was Vercel not applying Next.js routing (Framework Preset stuck on NestJS/Other from the initial apps/api import). Declaring framework in vercel.json forces the Next.js builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)